### PR TITLE
Scale io update ici 6761

### DIFF
--- a/task_dc_emc_scaleio.adoc
+++ b/task_dc_emc_scaleio.adoc
@@ -38,7 +38,7 @@ Note: These are common terminology mappings only and might not represent every c
 [cols=2*, options="header", cols"50,50"]
 |===
 |Field|Description 
-|ScaleIO|IP address or fully-qualified domain name of the ScaleIO
+|ScaleIO Gateway|IP addresses or FQDNs of ScaleIO gateways, separated by comma (,) or semicolon (;)
 |User Name|Admin user name used to log in to the ScaleIO device
 |Password|Password used to log in to the ScaleIO device
 |===

--- a/task_dc_emc_scaleio.adoc
+++ b/task_dc_emc_scaleio.adoc
@@ -38,7 +38,7 @@ Note: These are common terminology mappings only and might not represent every c
 [cols=2*, options="header", cols"50,50"]
 |===
 |Field|Description 
-|ScaleIO Gateway|IP addresses or FQDNs of ScaleIO gateways, separated by comma (,) or semicolon (;)
+|ScaleIO Gateway(s)|IP addresses or FQDNs of ScaleIO gateways, separated by comma (,) or semicolon (;)
 |User Name|Admin user name used to log in to the ScaleIO device
 |Password|Password used to log in to the ScaleIO device
 |===


### PR DESCRIPTION
ScaleIO now allows for multiple comma-separated IP's. Doc will now reflect this.