### PR TITLE
Default interval updates

### DIFF
--- a/concept_dashboard_features.adoc
+++ b/concept_dashboard_features.adoc
@@ -208,8 +208,8 @@ If you include a column for performance data (for example, _IOPS - Total_) in a 
 
 You can select the time range for your dashboard data. Only data relevant to the selected time range will be displayed in widgets on the dashboard.  You can select from the following time ranges:
 
-* Last 3 Hours
-* Last 24 Hours (this is the default)
+* Last 3 Hours (this is the default)
+* Last 24 Hours 
 * Last 3 Days
 * Last 7 Days
 * Last 30 Days

--- a/concept_whats_new.adoc
+++ b/concept_whats_new.adoc
@@ -28,8 +28,8 @@ The default time range for dashboards is now 3 Hours instead of 24 hours.
 
 Optimized time aggregation intervals in time-series widgets (Line, Spline, Area, and Stacked Area charts) are more frequent for 3-hour and 24-hour dashboard/widget time ranges, allowing for faster charting of data. 
 
-* 3 hour time range optimizes to 1 minute aggregation interval. Previously was 5 minute.
-* 24 hour time range optimizes to 30 minute aggregation interval. Previously was 1 hour.
+* 3 hour time range optimizes to a 1 minute aggregation interval. Previously this was 5 minutes.
+* 24 hour time range optimizes to a 30 minute aggregation interval. Previously this was 1 hour.
 
 You can still override the optimized aggregation by setting a custom interval.
 

--- a/concept_whats_new.adoc
+++ b/concept_whats_new.adoc
@@ -20,6 +20,18 @@ NetApp is continually improving and enhancing its products and services. Here ar
 
 === April 2020
 
+==== Default Dashboard Time
+
+The default time range for dashboards is now 3 Hours instead of 24 hours. Note that other Cloud Insights pages still default to 24 hours.
+
+==== Optimized Aggregation Times
+
+Optimized time aggregation in time-series widgets (Line, Spline, Area, and Stacked Area charts) is more frequent for 3-hour and 24-hour dashboard/widget time ranges, allowing for faster charting of data. 
+* 3 hour time range optimizes for 10-second aggregation
+* 24 hour time range optimizes for 1 minute aggregation
+
+You can still override the optimized aggregation by setting a custom interval.
+
 
 ==== Display Unit Auto-Format
 

--- a/concept_whats_new.adoc
+++ b/concept_whats_new.adoc
@@ -22,7 +22,7 @@ NetApp is continually improving and enhancing its products and services. Here ar
 
 ==== Default Dashboard Time
 
-The default time range for dashboards is now 3 Hours instead of 24 hours. Note that other Cloud Insights pages still default to 24 hours.
+The default time range for dashboards is now 3 Hours instead of 24 hours. 
 
 ==== Optimized Aggregation Times
 

--- a/concept_whats_new.adoc
+++ b/concept_whats_new.adoc
@@ -26,10 +26,10 @@ The default time range for dashboards is now 3 Hours instead of 24 hours. Note t
 
 ==== Optimized Aggregation Times
 
-Optimized time aggregation in time-series widgets (Line, Spline, Area, and Stacked Area charts) is more frequent for 3-hour and 24-hour dashboard/widget time ranges, allowing for faster charting of data. 
+Optimized time aggregation intervals in time-series widgets (Line, Spline, Area, and Stacked Area charts) is more frequent for 3-hour and 24-hour dashboard/widget time ranges, allowing for faster charting of data. 
 
-* 3 hour time range optimizes for 10-second aggregation
-* 24 hour time range optimizes for 1 minute aggregation
+* 3 hour time range optimizes to 1 minute aggregation interval. Previously was 5 minute.
+* 24 hour time range optimizes to 30 minute aggregation interval. Previously was 1 hour.
 
 You can still override the optimized aggregation by setting a custom interval.
 

--- a/concept_whats_new.adoc
+++ b/concept_whats_new.adoc
@@ -27,6 +27,7 @@ The default time range for dashboards is now 3 Hours instead of 24 hours. Note t
 ==== Optimized Aggregation Times
 
 Optimized time aggregation in time-series widgets (Line, Spline, Area, and Stacked Area charts) is more frequent for 3-hour and 24-hour dashboard/widget time ranges, allowing for faster charting of data. 
+
 * 3 hour time range optimizes for 10-second aggregation
 * 24 hour time range optimizes for 1 minute aggregation
 

--- a/concept_whats_new.adoc
+++ b/concept_whats_new.adoc
@@ -26,7 +26,7 @@ The default time range for dashboards is now 3 Hours instead of 24 hours. Note t
 
 ==== Optimized Aggregation Times
 
-Optimized time aggregation intervals in time-series widgets (Line, Spline, Area, and Stacked Area charts) is more frequent for 3-hour and 24-hour dashboard/widget time ranges, allowing for faster charting of data. 
+Optimized time aggregation intervals in time-series widgets (Line, Spline, Area, and Stacked Area charts) are more frequent for 3-hour and 24-hour dashboard/widget time ranges, allowing for faster charting of data. 
 
 * 3 hour time range optimizes to 1 minute aggregation interval. Previously was 5 minute.
 * 24 hour time range optimizes to 30 minute aggregation interval. Previously was 1 hour.

--- a/concept_whats_new.adoc
+++ b/concept_whats_new.adoc
@@ -26,7 +26,7 @@ The default time range for dashboards is now 3 Hours instead of 24 hours.
 
 ==== Optimized Aggregation Times
 
-Optimized time aggregation intervals in time-series widgets (Line, Spline, Area, and Stacked Area charts) are more frequent for 3-hour and 24-hour dashboard/widget time ranges, allowing for faster charting of data. 
+Optimized link:http://concept_dashboard_features.html#aggregating-data[time aggregation] intervals in time-series widgets (Line, Spline, Area, and Stacked Area charts) are more frequent for 3-hour and 24-hour dashboard/widget time ranges, allowing for faster charting of data. 
 
 * 3 hour time range optimizes to a 1 minute aggregation interval. Previously this was 5 minutes.
 * 24 hour time range optimizes to a 30 minute aggregation interval. Previously this was 1 hour.


### PR DESCRIPTION
What's New entries for 

- New default dashboard time range of 3 hours
- New aggregation intervals
- Move note on dashboard features page - Last 24 Hours (this is the default) - to the 3 hour bullet