### PR TITLE
Update task_dc_na_hci.adoc

### DIFF
--- a/task_dc_na_hci.adoc
+++ b/task_dc_na_hci.adoc
@@ -111,6 +111,7 @@ Some things to try if you encounter problems with this data collector:
 |Error: Failed to instantiate a connection to VirtualCenter at IP
 |Possible solutions:
 
+* Use vpshere.local account for login. Do not add the @vsphere.local to the user name. i.e. for administrator@vsphere.local, specify administrator.
 * Verify credentials and IP address entered.
 * Try to communicate with Virtual Center using Infrastructure Client.
 * Try to communicate with Virtual Center using Managed Object Browser (e.g MOB).


### PR DESCRIPTION
CI will not allow you to add a vcenter username with the full name resolution (i.e. administrator@vsphere.local). It is expecting to use an @vsphere.local account, but without the @vsphere.local. I tested this with both administrator and a new vsphere.local user I created, called kp@vpshere.local. This method works. If you add the full name, it will fail to add the collector. It will successfully add if I just enter kp or administrator under VCenter User Name.