### PR TITLE
Update task_dc_na_cdot.adoc

### DIFF
--- a/task_dc_na_cdot.adoc
+++ b/task_dc_na_cdot.adoc
@@ -42,8 +42,7 @@ The following are requirements to configure and use this data collector:
 * You must have access to an Administrator account used for read-only API calls.
 * Username (with read-only role name to ontapi application to the default Vserver) and password to log into NetApp cluster)
 * Port requirements: 80 or 443
-* License requirements:
-** FCP license and mapped/masked volumes required for discovery 
+
 
 == Configuration 
 


### PR DESCRIPTION
Our cDOT collector should have no dependency on FCP license - we support cDOT clusters with only IP protocols, etc