### PR TITLE
add space requirement for /tmp

### DIFF
--- a/concept_acquisition_unit_requirements.adoc
+++ b/concept_acquisition_unit_requirements.adoc
@@ -55,6 +55,7 @@ This computer should be running no other application-level software. A dedicated
 For Linux, disk space should be allocated in this manner:
 /opt/netapp 10 GB
 /var/log/netapp 40 GB
+/tmp 1GB free space during installation
 |50 GB
 |Network	|100 Mbps /1 Gbps Ethernet connection, static IP address, IP connectivity to all FC devices, and a required port to the Cloud Insights instance (80 or 443). 
 |Same 


### PR DESCRIPTION
During installation it is necessary to have enough free space in /tmp. Otherwise the uncompress will fail.