### PR TITLE
remove stray lines

### DIFF
--- a/concept_feature_tutorials.adoc
+++ b/concept_feature_tutorials.adoc
@@ -4,9 +4,7 @@ permalink: concept_feature_tutorials.html
 summary: Cloud Insights has tutorials to show you how to perform many tasks.
 keywords: onboarding, getting started, video, tutorial, resolution, dashboard, query, troubleshooting
 ---
-
 = Feature Tutorials
-
 :toc: macro
 :hardbreaks:
 :toclevels: 2


### PR DESCRIPTION
@netapp-alavoie - This topic was reported as having non-working videos on the German site. While investigating, I noticed that the images are also missing. The two empty lines on either side of the title are known to cause the missing image problem with localized sites. (They are technically incorrect for English, but don't seem to break anything. Go figure.)

I'm updating this file directly in public to see if the video failure is caused by the same thing. 