### PR TITLE
Update reference_data_collector_support_matrix.adoc

### DIFF
--- a/reference_data_collector_support_matrix.adoc
+++ b/reference_data_collector_support_matrix.adoc
@@ -27,127 +27,8 @@ toc::[]
 
 Models and versions supported by this data collector:
 |===
-<.<|API versions <.<|Models <.<|Firmware versions 
+<.<|Models <.<|Firmware versions 
 
-|3.1.1 (MU1)
-3.1.1 (MU1) P10
-3.1.2 (MU3) P16
-3.1.3 (MU1) P07
-3.1.3 (MU2)
-3.1.3 (MU3)
-3.2.1 (MU3) P17
-3.2.1 (MU5) P49
-3.2.2 (MU2) P14
-3.2.2 (MU4) P56
-3.2.2 (MU6) P96
-3.2.2 (MU6) P99
-3.2.2 P03
-3.3.1 (MU1) P09
-3.3.1 (MU2) P30
-3.3.1 (MU2) P32
-3.3.1 (MU5) P126
-3.3.1 (MU5) P132
-3.3.2 (MU1)
-3.3.2 (MU1) P04
-3.3.2 P01
-4.4.1 Release Type: Standard Support Release
-4.5.11 Release Type: Extended Support Release
-4.5.3 Release Type: Extended Support Release
-4.5.7 Release Type: Extended Support Release
-9.5.8 Release Type: Extended Support Release
-P02
-P04
-P05
-P08
-P09
-P103
-P106
-P107
-P11
-P111
-P113
-P115
-P118
-P119
-P127
-P13
-P131
-P132
-P133
-P135
-P138
-P139
-P140
-P141
-P142
-P146
-P148
-P149
-P15
-P150
-P151
-P152
-P153
-P154
-P155
-P156
-P157
-P160
-P161
-P162
-P164
-P165
-P166
-P167
-P168
-P170
-P172
-P173
-P175
-P177
-P18
-P180
-P19
-P22
-P23
-P25
-P27
-P29
-P30
-P32
-P34
-P36
-P37
-P39
-P40
-P41
-P42
-P45
-P48
-P49
-P50
-P51
-P52
-P53
-P56
-P57
-P59
-P60
-P70
-P71
-P72
-P73
-P75
-P76
-P78
-P80
-P85
-P90
-P93
-P94
-P96
-P98
-P99
 |HPE Alletra 9080
 HPE_3PAR 20450
 HPE_3PAR 20800
@@ -178,124 +59,26 @@ InServ T400
 InServ T800
 InServ V400
 |3.1.1 (MU1)
-3.1.1 (MU1) P10
-3.1.2 (MU3) P16
-3.1.3 (MU1) P07
+3.1.2 (MU3)
+3.1.3 (MU1)
 3.1.3 (MU2)
 3.1.3 (MU3)
-3.2.1 (MU3) P17
-3.2.1 (MU5) P49
-3.2.2 (MU2) P14
-3.2.2 (MU4) P56
-3.2.2 (MU6) P96
-3.2.2 (MU6) P99
-3.2.2 P03
-3.3.1 (MU1) P09
-3.3.1 (MU2) P30
-3.3.1 (MU2) P32
-3.3.1 (MU5) P126
-3.3.1 (MU5) P132
+3.2.1 (MU3)
+3.2.1 (MU5)
+3.2.2
+3.2.2 (MU2)
+3.2.2 (MU4)
+3.2.2 (MU6)
+3.3.1 (MU1)
+3.3.1 (MU2)
+3.3.1 (MU5)
+3.3.2
 3.3.2 (MU1)
-3.3.2 (MU1) P04
-3.3.2 P01
 4.4.1 Release Type: Standard Support Release
 4.5.11 Release Type: Extended Support Release
 4.5.3 Release Type: Extended Support Release
 4.5.7 Release Type: Extended Support Release
 9.5.8 Release Type: Extended Support Release
-P02
-P04
-P05
-P08
-P09
-P103
-P106
-P107
-P11
-P111
-P113
-P115
-P118
-P119
-P127
-P13
-P131
-P132
-P133
-P135
-P138
-P139
-P140
-P141
-P142
-P146
-P148
-P149
-P15
-P150
-P151
-P152
-P153
-P154
-P155
-P156
-P157
-P160
-P161
-P162
-P164
-P165
-P166
-P167
-P168
-P170
-P172
-P173
-P175
-P177
-P18
-P180
-P19
-P22
-P23
-P25
-P27
-P29
-P30
-P32
-P34
-P36
-P37
-P39
-P40
-P41
-P42
-P45
-P48
-P49
-P50
-P51
-P52
-P53
-P56
-P57
-P59
-P60
-P70
-P71
-P72
-P73
-P75
-P76
-P78
-P80
-P85
-P90
-P93
-P94
-P96
-P98
-P99
 
 |===
 Products supported by this data collector:
@@ -650,9 +433,8 @@ Management APIs used by this data collector:
 
 Models and versions supported by this data collector:
 |===
-<.<|API versions <.<|Models <.<|Firmware versions 
+<.<|Models <.<|Firmware versions 
 
-|2010-08-01
 |S3
 |2010-08-01
 
@@ -1230,9 +1012,8 @@ Management APIs used by this data collector:
 
 Models and versions supported by this data collector:
 |===
-<.<|API versions <.<|Models <.<|Firmware versions 
+<.<|Models <.<|Firmware versions 
 
-|v9.1.x
 |Brocade 6505
 Brocade G720
 Brocade X6-8
@@ -1756,16 +1537,8 @@ Management APIs used by this data collector:
 
 Models and versions supported by this data collector:
 |===
-<.<|API versions <.<|Models <.<|Firmware versions 
+<.<|Models <.<|Firmware versions 
 
-|5.5.38-1
-6.0.65-2
-7.1.76-4
-7.1.79-8
-7.1.83-2
-8.1.21-266
-8.1.21-303
-8.1.9-155
 |NS-480FC
 NSX
 VG8
@@ -2684,7 +2457,8 @@ Models and versions supported by this data collector:
 |===
 <.<|Models <.<|Firmware versions 
 
-|A200
+|
+A200
 A2000
 A300
 F200
@@ -2694,16 +2468,13 @@ H400
 H500
 H600
 H700
-Message from syslogd@ersk
 NL400
 NL410
 S210
-SIMULATOR
 X200
 X210
 X400
 X410
-infinity_hba_bay_to_unit: no da device pass7
 |9.1.0.10
 9.1.0.12
 9.1.0.16
@@ -3204,10 +2975,8 @@ Management APIs used by this data collector:
 
 Models and versions supported by this data collector:
 |===
-<.<|API versions <.<|Models <.<|Firmware versions 
+<.<|Models <.<|Firmware versions 
 
-|2.5
-3.5
 |ScaleIO
 |R2_6.11000.113
 R2_6.11000.115
@@ -3339,7 +3108,8 @@ Models and versions supported by this data collector:
 |===
 <.<|API versions <.<|Models <.<|Firmware versions 
 
-|V10.0.0.0
+|
+V10.0.0.0
 V10.0.1.0
 V7.6.2.67
 V8.3.0.22
@@ -3361,7 +3131,6 @@ V9.2.3.5
 V9.2.3.6
 V9.2.4.1
 V9.2.4.2
-unavailable
 |DMX3-24
 DMX4-24
 PMax2000
@@ -3869,12 +3638,8 @@ Management APIs used by this data collector:
 
 Models and versions supported by this data collector:
 |===
-<.<|API versions <.<|Models <.<|Firmware versions 
+<.<|Models <.<|Firmware versions 
 
-|7.1.76-4
-7.1.80-3
-7.33
-8.1.9-232
 |VNX5300
 VNX5400
 VNX5700
@@ -6122,7 +5887,7 @@ Management APIs used by this data collector:
 == IBM Cleversafe
 :description: Support Matrix Asciidoc for IBM Cleversafe
 
-Models and versions supported by this data collector:
+
 |===
 
 
@@ -6386,7 +6151,7 @@ Management APIs used by this data collector:
 == IBM PowerVM (SSH)
 :description: Support Matrix Asciidoc for IBM PowerVM (SSH)
 
-Models and versions supported by this data collector:
+
 |===
 
 
@@ -7168,7 +6933,7 @@ Management APIs used by this data collector:
 == Microsoft Hyper-V
 :description: Support Matrix Asciidoc for Microsoft Hyper-V
 
-Models and versions supported by this data collector:
+
 |===
 
 
@@ -7341,12 +7106,12 @@ Models and versions supported by this data collector:
 |===
 <.<|API versions <.<|Models <.<|Firmware versions 
 
-|ONTAPI version=1.12
-ONTAPI version=1.14
-ONTAPI version=1.17
-ONTAPI version=1.19
-ONTAPI version=1.20
-ONTAPI version=1.21
+|1.12
+1.14
+1.17
+1.19
+1.20
+1.21
 |FAS2040
 FAS2050
 FAS2220
@@ -7792,15 +7557,8 @@ Management APIs used by this data collector:
 
 Models and versions supported by this data collector:
 |===
-<.<|API versions <.<|Models <.<|Firmware versions 
+<.<|Models <.<|Firmware versions 
 
-|NetApp Release 9.11.0P1: Tue Mar 22 17:41:04 UTC 2022
-NetApp Release 9.11.1P3: Thu Sep 29 16:06:51 UTC 2022
-NetApp Release 9.11.1P5: Sat Dec 10 23:54:17 UTC 2022
-NetApp Release 9.11.1P6: Fri Jan 27 03:16:05 UTC 2023
-NetApp Release 9.11.1P7: Thu Mar 09 11:22:24 UTC 2023
-NetApp Release 9.11.1P9: Fri Apr 28 03:24:07 UTC 2023
-NetApp Release 9.12.1P4: Tue Jun 06 20:41:34 UTC 2023
 |FSx for ONTAP
 |Data ONTAP
 
@@ -8039,220 +7797,8 @@ Management APIs used by this data collector:
 
 Models and versions supported by this data collector:
 |===
-<.<|API versions <.<|Models <.<|Firmware versions 
+<.<|Models <.<|Firmware versions 
 
-|Data ONTAP Release 9.12.1P2: Wed Apr 05 19:57:43 UTC 2023 (Lenovo)
-NetApp Release 8.2.3P5 Cluster-Mode: Thu Jul 16 21:51:07 PDT 2015
-NetApp Release 8.3.1: Mon Aug 31 12:42:08 UTC 2015
-NetApp Release 8.3.1P2: Wed Dec 09 03:10:24 UTC 2015
-NetApp Release 8.3.2: Wed Feb 24 03:29:11 UTC 2016
-NetApp Release 8.3.2P12: Mon Aug 14 02:57:01 UTC 2017
-NetApp Release 8.3.2P2: Mon May 23 13:45:25 UTC 2016
-NetApp Release 8.3.2P5: Tue Aug 23 12:36:56 UTC 2016
-NetApp Release 8.3: Mon Mar 09 23:01:28 PDT 2015
-NetApp Release 9.10.0: Thu Aug 19 01:19:53 UTC 2021
-NetApp Release 9.10.1: Sat Jan 15 10:49:44 UTC 2022
-NetApp Release 9.10.1: Sat Jan 15 15:04:44 UTC 2022
-NetApp Release 9.10.1P10: Sun Dec 18 16:24:34 UTC 2022
-NetApp Release 9.10.1P11: Thu Feb 23 06:55:33 UTC 2023
-NetApp Release 9.10.1P12: Thu Apr 13 00:30:59 UTC 2023
-NetApp Release 9.10.1P13: Mon Jun 19 06:30:54 UTC 2023
-NetApp Release 9.10.1P1: Sun Feb 20 04:09:09 UTC 2022
-NetApp Release 9.10.1P2: Sun Mar 13 07:13:58 UTC 2022
-NetApp Release 9.10.1P3: Tue Apr 19 17:44:44 UTC 2022
-NetApp Release 9.10.1P4: Mon May 09 22:11:44 UTC 2022
-NetApp Release 9.10.1P5: Sun Jun 19 14:49:57 UTC 2022
-NetApp Release 9.10.1P6: Fri Jul 01 12:06:33 UTC 2022
-NetApp Release 9.10.1P7: Tue Aug 02 08:59:50 UTC 2022
-NetApp Release 9.10.1P8: Tue Sep 13 14:10:13 UTC 2022
-NetApp Release 9.10.1P9: Thu Nov 03 23:29:00 UTC 2022
-NetApp Release 9.10.1RC1: Wed Oct 27 02:46:19 UTC 2021
-NetApp Release 9.11.0P1: Tue Mar 22 17:41:04 UTC 2022
-NetApp Release 9.11.1: Tue Jul 12 04:38:28 UTC 2022
-NetApp Release 9.11.1: Tue Jul 12 10:21:46 UTC 2022
-NetApp Release 9.11.1P10: Thu May 25 12:28:26 UTC 2023
-NetApp Release 9.11.1P1: Tue Aug 09 13:13:19 UTC 2022
-NetApp Release 9.11.1P2: Mon Sep 05 03:40:01 UTC 2022
-NetApp Release 9.11.1P3: Thu Sep 29 16:06:51 UTC 2022
-NetApp Release 9.11.1P4: Thu Oct 27 11:37:48 UTC 2022
-NetApp Release 9.11.1P5: Sat Dec 10 23:54:17 UTC 2022
-NetApp Release 9.11.1P6: Fri Jan 27 03:16:05 UTC 2023
-NetApp Release 9.11.1P7: Thu Mar 09 11:22:24 UTC 2023
-NetApp Release 9.11.1P8: Fri Apr 07 00:02:50 UTC 2023
-NetApp Release 9.11.1P9: Fri Apr 28 03:24:07 UTC 2023
-NetApp Release 9.11.1RC1: Wed Apr 27 06:57:10 UTC 2022
-NetApp Release 9.11.1X12: Thu Mar 24 16:38:36 UTC 2022
-NetApp Release 9.11.1X26: Thu Jun 02 09:48:39 UTC 2022
-NetApp Release 9.12.1: Wed Feb 01 01:10:18 UTC 2023
-NetApp Release 9.12.1P1: Wed Feb 22 18:22:20 UTC 2023
-NetApp Release 9.12.1P2: Wed Apr 05 14:58:46 UTC 2023
-NetApp Release 9.12.1P2: Wed Apr 05 19:57:43 UTC 2023
-NetApp Release 9.12.1P3: Tue May 02 13:02:11 UTC 2023
-NetApp Release 9.12.1P4: Tue Jun 06 20:41:34 UTC 2023
-NetApp Release 9.12.1RC1: Fri Nov 04 11:45:36 UTC 2022
-NetApp Release 9.12.1RC1: Wed Nov 09 01:14:48 UTC 2022
-NetApp Release 9.13.0: Tue Feb 07 21:20:29 UTC 2023
-NetApp Release 9.13.0P1: Mon Mar 27 03:33:38 UTC 2023
-NetApp Release 9.13.0P2: Tue Apr 11 15:05:31 UTC 2023
-NetApp Release 9.13.0P3: Wed May 17 16:31:25 UTC 2023
-NetApp Release 9.13.1: Mon Jun 19 13:36:41 UTC 2023
-NetApp Release 9.13.1RC1: Wed Apr 26 15:07:24 UTC 2023
-NetApp Release 9.13.1X19: Mon Apr 03 20:51:32 UTC 2023
-NetApp Release 9.13.1X25: Wed Apr 26 15:07:24 UTC 2023
-NetApp Release 9.13.1X33: Mon May 29 12:34:33 UTC 2023
-NetApp Release 9.13.1X34: Thu Jun 08 10:20:00 UTC 2023
-NetApp Release 9.13.1X35: Mon Jun 12 12:12:13 UTC 2023
-NetApp Release 9.13.1X36: Thu Jun 15 13:39:29 UTC 2023
-NetApp Release 9.1: Fri Dec 23 04:09:51 UTC 2016
-NetApp Release 9.1P10: Tue Nov 14 18:03:02 UTC 2017
-NetApp Release 9.1P11: Thu Dec 21 15:05:39 UTC 2017
-NetApp Release 9.1P12: Mon Mar 05 17:39:31 UTC 2018
-NetApp Release 9.1P14: Wed Jun 27 09:15:16 UTC 2018
-NetApp Release 9.1P15: Thu Aug 30 08:19:59 UTC 2018
-NetApp Release 9.1P17: Thu Feb 28 08:05:25 UTC 2019
-NetApp Release 9.1P19: Mon May 27 09:09:01 UTC 2019
-NetApp Release 9.1P1: Tue Feb 14 13:14:46 UTC 2017
-NetApp Release 9.1P20: Mon Oct 28 14:37:28 UTC 2019
-NetApp Release 9.1P5: Sun Jun 11 02:26:58 UTC 2017
-NetApp Release 9.1P7: Mon Aug 14 10:27:14 UTC 2017
-NetApp Release 9.1P8: Wed Aug 30 13:33:41 UTC 2017
-NetApp Release 9.3P10: Sat Dec 15 04:24:49 UTC 2018
-NetApp Release 9.3P12: Mon Apr 01 23:33:10 UTC 2019
-NetApp Release 9.3P13: Mon May 27 19:26:00 UTC 2019
-NetApp Release 9.3P14: Wed Jul 10 14:38:46 UTC 2019
-NetApp Release 9.3P15: Tue Jul 16 19:40:35 UTC 2019
-NetApp Release 9.3P18: Mon Dec 30 10:39:53 UTC 2019
-NetApp Release 9.3P19: Fri Jul 10 12:47:52 UTC 2020
-NetApp Release 9.3P1: Mon Jan 22 18:01:29 UTC 2018
-NetApp Release 9.3P20: Wed Sep 23 21:44:43 UTC 2020
-NetApp Release 9.3P21: Mon Jan 11 17:25:42 UTC 2021
-NetApp Release 9.3P2: Fri Mar 02 01:02:58 UTC 2018
-NetApp Release 9.3P2: Thu Mar 01 16:53:13 UTC 2018
-NetApp Release 9.3P4: Fri Apr 27 19:34:03 UTC 2018
-NetApp Release 9.3P6: Thu Jun 14 20:21:25 UTC 2018
-NetApp Release 9.3P7: Wed Jul 25 10:11:10 UTC 2018
-NetApp Release 9.3P8: Mon Sep 03 20:01:35 UTC 2018
-NetApp Release 9.3P9: Thu Oct 25 07:42:13 UTC 2018
-NetApp Release 9.4P2: Tue Aug 21 00:00:08 UTC 2018
-NetApp Release 9.4P3: Thu Oct 11 22:23:50 UTC 2018
-NetApp Release 9.4P4: Thu Nov 01 15:18:22 UTC 2018
-NetApp Release 9.4P6: Fri Feb 22 09:43:14 UTC 2019
-NetApp Release 9.4RC1: Thu Apr 26 09:13:57 UTC 2018
-NetApp Release 9.5: Thu Dec 13 20:41:33 UTC 2018
-NetApp Release 9.5P10: Fri Dec 13 16:01:45 UTC 2019
-NetApp Release 9.5P12: Fri Apr 10 18:20:31 UTC 2020
-NetApp Release 9.5P13: Tue May 19 02:45:36 UTC 2020
-NetApp Release 9.5P14: Mon Aug 17 05:32:42 UTC 2020
-NetApp Release 9.5P15: Tue Nov 17 07:31:22 UTC 2020
-NetApp Release 9.5P16: Tue Jan 12 10:52:07 UTC 2021
-NetApp Release 9.5P17: Wed May 12 20:42:52 UTC 2021
-NetApp Release 9.5P18: Wed Aug 11 19:17:30 UTC 2021
-NetApp Release 9.5P19: Sat Nov 27 06:39:07 UTC 2021
-NetApp Release 9.5P1: Tue Feb 19 21:38:50 UTC 2019
-NetApp Release 9.5P2: Thu Mar 14 13:59:39 UTC 2019
-NetApp Release 9.5P3: Tue Apr 16 18:33:13 UTC 2019
-NetApp Release 9.5P3: Tue Apr 16 22:44:27 UTC 2019
-NetApp Release 9.5P4: Tue May 07 03:16:26 UTC 2019
-NetApp Release 9.5P5: Fri Jun 14 15:33:34 UTC 2019
-NetApp Release 9.5P6: Wed Jul 10 18:43:50 UTC 2019
-NetApp Release 9.5P6: Wed Jul 10 22:58:11 UTC 2019
-NetApp Release 9.5P7: Tue Aug 06 00:37:41 UTC 2019
-NetApp Release 9.5P8: Fri Sep 20 19:03:08 UTC 2019
-NetApp Release 9.5P9: Mon Oct 28 09:18:10 UTC 2019
-NetApp Release 9.6: Wed Jul 10 10:10:43 UTC 2019
-NetApp Release 9.6: Wed Jul 10 16:25:33 UTC 2019
-NetApp Release 9.6P11: Fri Oct 16 23:13:09 UTC 2020
-NetApp Release 9.6P14: Mon Apr 05 15:34:55 UTC 2021
-NetApp Release 9.6P15: Mon May 31 02:25:27 UTC 2021
-NetApp Release 9.6P18: Tue Apr 05 11:08:11 UTC 2022
-NetApp Release 9.6P2: Fri Jul 19 06:06:59 UTC 2019
-NetApp Release 9.6P3: Sun Sep 22 08:26:36 UTC 2019
-NetApp Release 9.6P4: Thu Nov 07 01:50:36 UTC 2019
-NetApp Release 9.6P5: Fri Dec 13 18:21:56 UTC 2019
-NetApp Release 9.6RC1: Sat May 11 05:58:14 UTC 2019
-NetApp Release 9.6X11: Sun Mar 10 12:15:04 UTC 2019
-NetApp Release 9.7: Thu Jan 09 17:11:21 UTC 2020
-NetApp Release 9.7P10: Thu Dec 10 00:55:43 UTC 2020
-NetApp Release 9.7P11: Tue Jan 12 18:41:08 UTC 2021
-NetApp Release 9.7P11: Tue Jan 12 23:00:49 UTC 2021
-NetApp Release 9.7P12: Tue Mar 02 23:38:44 UTC 2021
-NetApp Release 9.7P13: Thu Apr 15 02:06:46 UTC 2021
-NetApp Release 9.7P14: Thu Jun 10 22:54:31 UTC 2021
-NetApp Release 9.7P15: Fri Aug 06 19:56:41 UTC 2021
-NetApp Release 9.7P16: Fri Sep 10 22:33:12 UTC 2021
-NetApp Release 9.7P17: Sat Nov 27 13:49:53 UTC 2021
-NetApp Release 9.7P18: Thu Mar 10 09:57:16 UTC 2022
-NetApp Release 9.7P19: Mon May 23 20:55:08 UTC 2022
-NetApp Release 9.7P1: Thu Feb 27 01:25:24 UTC 2020
-NetApp Release 9.7P20: Thu Aug 11 13:20:52 UTC 2022
-NetApp Release 9.7P21: Fri Dec 23 11:52:44 UTC 2022
-NetApp Release 9.7P22: Mon Mar 27 14:06:51 UTC 2023
-NetApp Release 9.7P2: Sun Mar 22 21:50:44 UTC 2020
-NetApp Release 9.7P3: Fri Apr 17 14:37:51 UTC 2020
-NetApp Release 9.7P4: Sat May 23 00:43:42 UTC 2020
-NetApp Release 9.7P5: Tue Jun 23 04:02:30 UTC 2020
-NetApp Release 9.7P6: Tue Jul 28 04:06:27 UTC 2020
-NetApp Release 9.7P7: Thu Aug 27 20:57:05 UTC 2020
-NetApp Release 9.7P8: Thu Oct 15 04:11:57 UTC 2020
-NetApp Release 9.7P9: Fri Nov 06 01:13:45 UTC 2020
-NetApp Release 9.7RC1: Fri Nov 22 07:39:07 UTC 2019
-NetApp Release 9.7X17: Sat Nov 16 22:06:11 UTC 2019
-NetApp Release 9.8: Wed Dec 09 06:17:24 UTC 2020
-NetApp Release 9.8P10: Fri Feb 04 19:51:21 UTC 2022
-NetApp Release 9.8P11: Sat Mar 12 10:19:15 UTC 2022
-NetApp Release 9.8P11D2: Thu Apr 14 12:50:07 UTC 2022
-NetApp Release 9.8P12: Fri May 13 00:04:00 UTC 2022
-NetApp Release 9.8P13: Fri Jul 15 22:40:56 UTC 2022
-NetApp Release 9.8P14: Tue Aug 23 15:29:48 UTC 2022
-NetApp Release 9.8P15: Wed Nov 23 09:29:16 UTC 2022
-NetApp Release 9.8P16: Fri Dec 02 02:05:05 UTC 2022
-NetApp Release 9.8P16: Thu Dec 01 20:42:37 UTC 2022
-NetApp Release 9.8P17: Fri Feb 24 15:11:05 UTC 2023
-NetApp Release 9.8P18: Wed Mar 29 13:19:30 UTC 2023
-NetApp Release 9.8P19: Thu May 11 12:52:01 UTC 2023
-NetApp Release 9.8P19: Thu May 11 17:26:53 UTC 2023
-NetApp Release 9.8P1: Thu Jan 21 01:11:31 UTC 2021
-NetApp Release 9.8P2: Tue Feb 16 03:49:46 UTC 2021
-NetApp Release 9.8P3: Sat Mar 27 08:43:48 UTC 2021
-NetApp Release 9.8P4: Mon May 03 09:22:00 UTC 2021
-NetApp Release 9.8P5: Thu Jun 10 21:52:01 UTC 2021
-NetApp Release 9.8P6: Tue Aug 03 16:21:11 UTC 2021
-NetApp Release 9.8P7: Tue Sep 14 18:38:58 UTC 2021
-NetApp Release 9.8P8: Thu Oct 21 19:21:56 UTC 2021
-NetApp Release 9.8P9: Wed Dec 22 09:39:04 UTC 2021
-NetApp Release 9.8RC1: Sat Oct 31 11:13:09 UTC 2020
-NetApp Release 9.9.0: Fri Feb 05 11:29:21 UTC 2021
-NetApp Release 9.9.1: Sun Jun 13 06:06:29 UTC 2021
-NetApp Release 9.9.1: Sun Jun 13 11:45:05 UTC 2021
-NetApp Release 9.9.1P10: Fri May 27 16:22:46 UTC 2022
-NetApp Release 9.9.1P11: Tue Aug 02 19:12:28 UTC 2022
-NetApp Release 9.9.1P12: Fri Sep 16 20:50:11 UTC 2022
-NetApp Release 9.9.1P13: Fri Nov 18 17:29:45 UTC 2022
-NetApp Release 9.9.1P14: Fri Jan 27 21:45:51 UTC 2023
-NetApp Release 9.9.1P15: Mon Mar 27 12:31:36 UTC 2023
-NetApp Release 9.9.1P16: Thu May 25 01:06:07 UTC 2023
-NetApp Release 9.9.1P1: Fri Jul 02 20:21:27 UTC 2021
-NetApp Release 9.9.1P2: Thu Aug 19 13:53:06 UTC 2021
-NetApp Release 9.9.1P3: Sat Sep 25 13:10:46 UTC 2021
-NetApp Release 9.9.1P3: Wed Sep 29 12:55:55 UTC 2021
-NetApp Release 9.9.1P4: Mon Oct 11 09:20:31 UTC 2021
-NetApp Release 9.9.1P5: Sat Nov 20 12:17:23 UTC 2021
-NetApp Release 9.9.1P6: Tue Dec 21 13:38:22 UTC 2021
-NetApp Release 9.9.1P7: Sat Jan 29 01:25:00 UTC 2022
-NetApp Release 9.9.1P8: Tue Mar 15 22:46:53 UTC 2022
-NetApp Release 9.9.1P9: Wed Apr 20 00:42:19 UTC 2022
-NetApp Release Bluepaddle__9.7.0: Fri Nov 22 07:39:07 UTC 2019
-NetApp Release Dirtwolf__9.8.0: Tue Jan 18 07:07:03 UTC 2022
-NetApp Release Lighthouse__9.13.1: Mon Jun 19 07:42:08 UTC 2023
-NetApp Release Lighthouse__9.13.1: Sun Jun 18 05:17:33 UTC 2023
-NetApp Release Longboard__9.0.1: Sat Jun 04 09:45:33 UTC 2016
-NetApp Release Metropolitan__9.11.1: Tue Jul 12 04:38:28 UTC 2022
-NetApp Release Metropolitan__9.11.1: Wed Apr 27 01:48:31 UTC 2022
-NetApp Release Stormking__9.10.1: Sun Mar 13 02:23:34 UTC 2022
-NetApp Release Yellowdog__9.12.1: Mon Nov 28 22:02:55 UTC 2022
-NetApp Release Yellowdog__9.12.1: Tue Jan 31 19:19:43 UTC 2023
-NetApp Release Yellowdog__9.12.1: Tue Nov 08 20:32:25 UTC 2022
-NetApp Release Yellowdog__9.12.1: Wed Oct 05 05:47:17 UTC 2022
 |AFF-A150
 AFF-A200
 AFF-A220
@@ -8302,186 +7848,186 @@ FAS9500
 FASDvM300
 SIMBOX
 V6240
-|8.2.3P5 clustered Data ONTAP
-8.3.0 clustered Data ONTAP
-8.3.1 clustered Data ONTAP
-8.3.1P2 clustered Data ONTAP
-8.3.2 clustered Data ONTAP
-8.3.2P12 clustered Data ONTAP
-8.3.2P2 clustered Data ONTAP
-8.3.2P5 clustered Data ONTAP
-9.0.1 clustered Data ONTAP
-9.1.0 clustered Data ONTAP
-9.1.0P1 clustered Data ONTAP
-9.1.0P10 clustered Data ONTAP
-9.1.0P11 clustered Data ONTAP
-9.1.0P12 clustered Data ONTAP
-9.1.0P14 clustered Data ONTAP
-9.1.0P15 clustered Data ONTAP
-9.1.0P17 clustered Data ONTAP
-9.1.0P19 clustered Data ONTAP
-9.1.0P20 clustered Data ONTAP
-9.1.0P5 clustered Data ONTAP
-9.1.0P7 clustered Data ONTAP
-9.1.0P8 clustered Data ONTAP
-9.10.0 clustered Data ONTAP
-9.10.1 clustered Data ONTAP
-9.10.1P1 clustered Data ONTAP
-9.10.1P10 clustered Data ONTAP
-9.10.1P11 clustered Data ONTAP
-9.10.1P12 clustered Data ONTAP
-9.10.1P13 clustered Data ONTAP
-9.10.1P2 clustered Data ONTAP
-9.10.1P3 clustered Data ONTAP
-9.10.1P4 clustered Data ONTAP
-9.10.1P5 clustered Data ONTAP
-9.10.1P6 clustered Data ONTAP
-9.10.1P7 clustered Data ONTAP
-9.10.1P8 clustered Data ONTAP
-9.10.1P9 clustered Data ONTAP
-9.11.0P1 clustered Data ONTAP
-9.11.1 clustered Data ONTAP
-9.11.1P1 clustered Data ONTAP
-9.11.1P10 clustered Data ONTAP
-9.11.1P2 clustered Data ONTAP
-9.11.1P3 clustered Data ONTAP
-9.11.1P4 clustered Data ONTAP
-9.11.1P5 clustered Data ONTAP
-9.11.1P6 clustered Data ONTAP
-9.11.1P7 clustered Data ONTAP
-9.11.1P8 clustered Data ONTAP
-9.11.1P9 clustered Data ONTAP
-9.11.1X12 clustered Data ONTAP
-9.11.1X26 clustered Data ONTAP
-9.12.1 clustered Data ONTAP
-9.12.1P1 clustered Data ONTAP
-9.12.1P2 clustered Data ONTAP
-9.12.1P3 clustered Data ONTAP
-9.12.1P4 clustered Data ONTAP
-9.13.0 clustered Data ONTAP
-9.13.0P1 clustered Data ONTAP
-9.13.0P2 clustered Data ONTAP
-9.13.0P3 clustered Data ONTAP
-9.13.1 clustered Data ONTAP
-9.13.1X19 clustered Data ONTAP
-9.13.1X25 clustered Data ONTAP
-9.13.1X33 clustered Data ONTAP
-9.13.1X34 clustered Data ONTAP
-9.13.1X35 clustered Data ONTAP
-9.13.1X36 clustered Data ONTAP
-9.3.0P1 clustered Data ONTAP
-9.3.0P10 clustered Data ONTAP
-9.3.0P12 clustered Data ONTAP
-9.3.0P13 clustered Data ONTAP
-9.3.0P14 clustered Data ONTAP
-9.3.0P15 clustered Data ONTAP
-9.3.0P18 clustered Data ONTAP
-9.3.0P19 clustered Data ONTAP
-9.3.0P2 clustered Data ONTAP
-9.3.0P20 clustered Data ONTAP
-9.3.0P21 clustered Data ONTAP
-9.3.0P4 clustered Data ONTAP
-9.3.0P6 clustered Data ONTAP
-9.3.0P7 clustered Data ONTAP
-9.3.0P8 clustered Data ONTAP
-9.3.0P9 clustered Data ONTAP
-9.4.0 clustered Data ONTAP
-9.4.0P2 clustered Data ONTAP
-9.4.0P3 clustered Data ONTAP
-9.4.0P4 clustered Data ONTAP
-9.4.0P6 clustered Data ONTAP
-9.5.0 clustered Data ONTAP
-9.5.0P1 clustered Data ONTAP
-9.5.0P10 clustered Data ONTAP
-9.5.0P12 clustered Data ONTAP
-9.5.0P13 clustered Data ONTAP
-9.5.0P14 clustered Data ONTAP
-9.5.0P15 clustered Data ONTAP
-9.5.0P16 clustered Data ONTAP
-9.5.0P17 clustered Data ONTAP
-9.5.0P18 clustered Data ONTAP
-9.5.0P19 clustered Data ONTAP
-9.5.0P2 clustered Data ONTAP
-9.5.0P3 clustered Data ONTAP
-9.5.0P4 clustered Data ONTAP
-9.5.0P5 clustered Data ONTAP
-9.5.0P6 clustered Data ONTAP
-9.5.0P7 clustered Data ONTAP
-9.5.0P8 clustered Data ONTAP
-9.5.0P9 clustered Data ONTAP
-9.6.0 clustered Data ONTAP
-9.6.0P11 clustered Data ONTAP
-9.6.0P14 clustered Data ONTAP
-9.6.0P15 clustered Data ONTAP
-9.6.0P18 clustered Data ONTAP
-9.6.0P2 clustered Data ONTAP
-9.6.0P3 clustered Data ONTAP
-9.6.0P4 clustered Data ONTAP
-9.6.0P5 clustered Data ONTAP
-9.6.0X11 clustered Data ONTAP
-9.7.0 clustered Data ONTAP
-9.7.0P1 clustered Data ONTAP
-9.7.0P10 clustered Data ONTAP
-9.7.0P11 clustered Data ONTAP
-9.7.0P12 clustered Data ONTAP
-9.7.0P13 clustered Data ONTAP
-9.7.0P14 clustered Data ONTAP
-9.7.0P15 clustered Data ONTAP
-9.7.0P16 clustered Data ONTAP
-9.7.0P17 clustered Data ONTAP
-9.7.0P18 clustered Data ONTAP
-9.7.0P19 clustered Data ONTAP
-9.7.0P2 clustered Data ONTAP
-9.7.0P20 clustered Data ONTAP
-9.7.0P21 clustered Data ONTAP
-9.7.0P22 clustered Data ONTAP
-9.7.0P3 clustered Data ONTAP
-9.7.0P4 clustered Data ONTAP
-9.7.0P5 clustered Data ONTAP
-9.7.0P6 clustered Data ONTAP
-9.7.0P7 clustered Data ONTAP
-9.7.0P8 clustered Data ONTAP
-9.7.0P9 clustered Data ONTAP
-9.7.0X17 clustered Data ONTAP
-9.8.0 clustered Data ONTAP
-9.8.0P1 clustered Data ONTAP
-9.8.0P10 clustered Data ONTAP
-9.8.0P11 clustered Data ONTAP
-9.8.0P11D2 clustered Data ONTAP
-9.8.0P12 clustered Data ONTAP
-9.8.0P13 clustered Data ONTAP
-9.8.0P14 clustered Data ONTAP
-9.8.0P15 clustered Data ONTAP
-9.8.0P16 clustered Data ONTAP
-9.8.0P17 clustered Data ONTAP
-9.8.0P18 clustered Data ONTAP
-9.8.0P19 clustered Data ONTAP
-9.8.0P2 clustered Data ONTAP
-9.8.0P3 clustered Data ONTAP
-9.8.0P4 clustered Data ONTAP
-9.8.0P5 clustered Data ONTAP
-9.8.0P6 clustered Data ONTAP
-9.8.0P7 clustered Data ONTAP
-9.8.0P8 clustered Data ONTAP
-9.8.0P9 clustered Data ONTAP
-9.9.0 clustered Data ONTAP
-9.9.1 clustered Data ONTAP
-9.9.1P1 clustered Data ONTAP
-9.9.1P10 clustered Data ONTAP
-9.9.1P11 clustered Data ONTAP
-9.9.1P12 clustered Data ONTAP
-9.9.1P13 clustered Data ONTAP
-9.9.1P14 clustered Data ONTAP
-9.9.1P15 clustered Data ONTAP
-9.9.1P16 clustered Data ONTAP
-9.9.1P2 clustered Data ONTAP
-9.9.1P3 clustered Data ONTAP
-9.9.1P4 clustered Data ONTAP
-9.9.1P5 clustered Data ONTAP
-9.9.1P6 clustered Data ONTAP
-9.9.1P7 clustered Data ONTAP
-9.9.1P8 clustered Data ONTAP
-9.9.1P9 clustered Data ONTAP
+|8.2.3P5
+8.3.0
+8.3.1
+8.3.1P2
+8.3.2
+8.3.2P12
+8.3.2P2
+8.3.2P5
+9.0.1
+9.1.0
+9.1.0P1
+9.1.0P10
+9.1.0P11
+9.1.0P12
+9.1.0P14
+9.1.0P15
+9.1.0P17
+9.1.0P19
+9.1.0P20
+9.1.0P5
+9.1.0P7
+9.1.0P8
+9.10.0
+9.10.1
+9.10.1P1
+9.10.1P10
+9.10.1P11
+9.10.1P12
+9.10.1P13
+9.10.1P2
+9.10.1P3
+9.10.1P4
+9.10.1P5
+9.10.1P6
+9.10.1P7
+9.10.1P8
+9.10.1P9
+9.11.0P1
+9.11.1
+9.11.1P1
+9.11.1P10
+9.11.1P2
+9.11.1P3
+9.11.1P4
+9.11.1P5
+9.11.1P6
+9.11.1P7
+9.11.1P8
+9.11.1P9
+9.11.1X12
+9.11.1X26
+9.12.1
+9.12.1P1
+9.12.1P2
+9.12.1P3
+9.12.1P4
+9.13.0
+9.13.0P1
+9.13.0P2
+9.13.0P3
+9.13.1
+9.13.1X19
+9.13.1X25
+9.13.1X33
+9.13.1X34
+9.13.1X35
+9.13.1X36
+9.3.0P1
+9.3.0P10
+9.3.0P12
+9.3.0P13
+9.3.0P14
+9.3.0P15
+9.3.0P18
+9.3.0P19
+9.3.0P2
+9.3.0P20
+9.3.0P21
+9.3.0P4
+9.3.0P6
+9.3.0P7
+9.3.0P8
+9.3.0P9
+9.4.0
+9.4.0P2
+9.4.0P3
+9.4.0P4
+9.4.0P6
+9.5.0
+9.5.0P1
+9.5.0P10
+9.5.0P12
+9.5.0P13
+9.5.0P14
+9.5.0P15
+9.5.0P16
+9.5.0P17
+9.5.0P18
+9.5.0P19
+9.5.0P2
+9.5.0P3
+9.5.0P4
+9.5.0P5
+9.5.0P6
+9.5.0P7
+9.5.0P8
+9.5.0P9
+9.6.0
+9.6.0P11
+9.6.0P14
+9.6.0P15
+9.6.0P18
+9.6.0P2
+9.6.0P3
+9.6.0P4
+9.6.0P5
+9.6.0X11
+9.7.0
+9.7.0P1
+9.7.0P10
+9.7.0P11
+9.7.0P12
+9.7.0P13
+9.7.0P14
+9.7.0P15
+9.7.0P16
+9.7.0P17
+9.7.0P18
+9.7.0P19
+9.7.0P2
+9.7.0P20
+9.7.0P21
+9.7.0P22
+9.7.0P3
+9.7.0P4
+9.7.0P5
+9.7.0P6
+9.7.0P7
+9.7.0P8
+9.7.0P9
+9.7.0X17
+9.8.0
+9.8.0P1
+9.8.0P10
+9.8.0P11
+9.8.0P11D2
+9.8.0P12
+9.8.0P13
+9.8.0P14
+9.8.0P15
+9.8.0P16
+9.8.0P17
+9.8.0P18
+9.8.0P19
+9.8.0P2
+9.8.0P3
+9.8.0P4
+9.8.0P5
+9.8.0P6
+9.8.0P7
+9.8.0P8
+9.8.0P9
+9.9.0
+9.9.1
+9.9.1P1
+9.9.1P10
+9.9.1P11
+9.9.1P12
+9.9.1P13
+9.9.1P14
+9.9.1P15
+9.9.1P16
+9.9.1P2
+9.9.1P3
+9.9.1P4
+9.9.1P5
+9.9.1P6
+9.9.1P7
+9.9.1P8
+9.9.1P9
 
 |===
 Products supported by this data collector:
@@ -9534,7 +9080,7 @@ Management APIs used by this data collector:
 == OpenStack (REST API / SSH)
 :description: Support Matrix Asciidoc for OpenStack (REST API / SSH)
 
-Models and versions supported by this data collector:
+
 |===
 
 
@@ -10112,7 +9658,7 @@ Management APIs used by this data collector:
 == Red Hat RHV (REST)
 :description: Support Matrix Asciidoc for Red Hat RHV (REST)
 
-Models and versions supported by this data collector:
+
 |===
 
 


### PR DESCRIPTION
Update:
Remove API versions:
o	Amazon FSx
o	NetApp Clustered Data ONTAP 8.1.1+
o	HP Enterprise 3PAR / Alletra 9000 / Primera StoreServ Storage
o	EMC VNX SSH
o	EMC Scalio Powerflex rest
o	Brocade FOS Rest

Remove duplicates in API vs Firmware Version columns(if true, retain Firmware Version and remove API Version):
o	3PAR
o	EMC Celerra
o	EMC VNX

Remove substrings and dedupe.
o	3PAR - Remove from API and Firmware versions: Remove P*
o	Dell EMC Isilon /Powerscale CLI - Remove from models: 'Message from syslogd@ersk',  'SIMULATOR', 'infinity_hba_bay_to_unit: no da device pass7'
o	EMC Symmetrix CLI - Remove API Version values: 'unavailable'
o	NetApp 7 Mode- Remove API Version values: 'ONTAPI version='
o	NetApp Clustered Data ONTAP 8.1.1+ - Remove from firmware: 'clustered Data ONTAP'
