### PR TITLE
Update task_dc_rubrik_cdm.adoc

### DIFF
--- a/task_dc_rubrik_cdm.adoc
+++ b/task_dc_rubrik_cdm.adoc
@@ -41,8 +41,8 @@ Note: These are common terminology mappings only and might not represent every c
 The following are required to configure this data collector:
 
 * The Cloud Insights Acquisition Unit will initiate connections to TCP port 443 to Rubrik cluster. One collector per cluster.
-* Rubrik cluster IP address.
-* User name and password to the cluster.
+* Rubrik cluster IP address or hostname.
+* For Basic Authentication, a user name and password to the cluster. If you prefer to use Service Account based authentication, you need a Service Account, Secret, and an Organization ID
 * Port requirement: HTTPS 443
 
 


### PR DESCRIPTION
We have added a second supported approach for Rubrik Authentication. The way it works is that if the customer populates the Organization ID field, we use that field + the username + password fields to perform "service account" authentication as opposed to the traditional "Basic Auth" approach in HTTP.